### PR TITLE
fix: less generous entity targeting for ray

### DIFF
--- a/src/main/java/alexthw/not_enough_glyphs/common/glyphs/forms/MethodRay.java
+++ b/src/main/java/alexthw/not_enough_glyphs/common/glyphs/forms/MethodRay.java
@@ -65,12 +65,10 @@ public class MethodRay extends AbstractCastMethod {
         BlockHitResult blockTarget = world.clip(rayTraceContext);
 
         if (blockTarget.getType() != HitResult.Type.MISS) {
-            BlockPos pos = blockTarget.getBlockPos();
-            Vec3 blockCenter = Vec3.atCenterOf(pos);
-            double distance = fromPoint.distanceTo(blockCenter) + 0.5d;
+            double distance = fromPoint.distanceTo(blockTarget.getLocation());
             toPoint = fromPoint.add(viewVector.scale(Math.min(range, distance)));
         }
-        EntityHitResult entityTarget = ProjectileUtil.getEntityHitResult(world, shooter, fromPoint, toPoint, new AABB(fromPoint, toPoint).inflate(1.5d), e -> e != shooter && e.isAlive() && e instanceof Entity);
+        EntityHitResult entityTarget = ProjectileUtil.getEntityHitResult(world, shooter, fromPoint, toPoint, new AABB(fromPoint, toPoint).inflate(1.5d), e -> e != shooter && e.isAlive() && e instanceof Entity, 0.0F);
 
 
         if (entityTarget != null) {


### PR DESCRIPTION
Ray currently takes way too much priority of entities over blocks due to `ProjectileUtil.getEntityHitResult`'s default hitbox inflation of 0.3 and because the end point and distance given to it can go through the block.
The first issue can be circumvented by passing 0.0 to `inflationAmount` in its overload, while the second can be solved by using `BlockHitResult#getLocation`.