### PR TITLE
Fix crash when Ars Elemental is not installed

### DIFF
--- a/src/main/java/alexthw/not_enough_glyphs/init/ArsElementalCompatRegistry.java
+++ b/src/main/java/alexthw/not_enough_glyphs/init/ArsElementalCompatRegistry.java
@@ -1,0 +1,29 @@
+package alexthw.not_enough_glyphs.init;
+
+import alexthw.ars_elemental.common.glyphs.MethodArcProjectile;
+import alexthw.ars_elemental.common.glyphs.MethodHomingProjectile;
+import alexthw.ars_elemental.common.glyphs.PropagatorArc;
+import alexthw.ars_elemental.common.glyphs.PropagatorHoming;
+import alexthw.not_enough_glyphs.common.spell.FocusPerk;
+import com.hollingsworth.arsnouveau.api.registry.PerkRegistry;
+
+import java.util.List;
+
+/**
+ * Compat class that is only loaded when Ars Elemental is present.
+ * Keeps Ars Elemental class references out of ArsNouveauRegistry to avoid
+ * NoClassDefFoundError when Ars Elemental is not installed.
+ */
+public class ArsElementalCompatRegistry {
+
+    public static void register() {
+        ArsNouveauRegistry.registeredSpells.addAll(List.of(
+                MethodArcProjectile.INSTANCE, MethodHomingProjectile.INSTANCE,
+                PropagatorArc.INSTANCE, PropagatorHoming.INSTANCE)
+        );
+        PerkRegistry.registerPerk(FocusPerk.ELEMENTAL_FIRE);
+        PerkRegistry.registerPerk(FocusPerk.ELEMENTAL_WATER);
+        PerkRegistry.registerPerk(FocusPerk.ELEMENTAL_EARTH);
+        PerkRegistry.registerPerk(FocusPerk.ELEMENTAL_AIR);
+    }
+}

--- a/src/main/java/alexthw/not_enough_glyphs/init/ArsNouveauRegistry.java
+++ b/src/main/java/alexthw/not_enough_glyphs/init/ArsNouveauRegistry.java
@@ -1,9 +1,5 @@
 package alexthw.not_enough_glyphs.init;
 
-import alexthw.ars_elemental.common.glyphs.MethodArcProjectile;
-import alexthw.ars_elemental.common.glyphs.MethodHomingProjectile;
-import alexthw.ars_elemental.common.glyphs.PropagatorArc;
-import alexthw.ars_elemental.common.glyphs.PropagatorHoming;
 import alexthw.not_enough_glyphs.api.spell_style.MissileTimeline;
 import alexthw.not_enough_glyphs.api.spell_style.RayMotion;
 import alexthw.not_enough_glyphs.api.spell_style.RayTimeline;
@@ -144,15 +140,7 @@ public class ArsNouveauRegistry {
             register(PropagateArc.INSTANCE);
             register(PropagateHoming.INSTANCE);
         } else {
-
-            registeredSpells.addAll(List.of(
-                    MethodArcProjectile.INSTANCE, MethodHomingProjectile.INSTANCE,
-                    PropagatorArc.INSTANCE, PropagatorHoming.INSTANCE)
-            );
-            PerkRegistry.registerPerk(FocusPerk.ELEMENTAL_FIRE);
-            PerkRegistry.registerPerk(FocusPerk.ELEMENTAL_WATER);
-            PerkRegistry.registerPerk(FocusPerk.ELEMENTAL_EARTH);
-            PerkRegistry.registerPerk(FocusPerk.ELEMENTAL_AIR);
+            ArsElementalCompatRegistry.register();
         }
 
         //ex scalaes


### PR DESCRIPTION
## Summary
- **Bug:** NEG crashes with `NoClassDefFoundError: alexthw/ars_elemental/common/glyphs/MethodHomingProjectile` when launched without Ars Elemental
- **Cause:** `ArsNouveauRegistry` had top-level imports of Ars Elemental classes, which the JVM resolves at class load time regardless of the runtime `ModList.isLoaded()` check
- **Fix:** Moved Ars Elemental registration into a separate `ArsElementalCompatRegistry` class that is only loaded when Ars Elemental is present

Fixes #3

## Test plan
- [x] Build succeeds with JDK 21
- [x] Clean boot on 1.21.1 NeoForge **without** Ars Elemental installed (previously crashed)
- [x] In-game playtest verified NEG glyphs work correctly without Ars Elemental