### PR TITLE
Register perk-items deterministically via RegisterEvent (fixes client/server perk-item desync that crashes MP join)

### DIFF
--- a/src/main/java/alexthw/not_enough_glyphs/init/ArsNouveauRegistry.java
+++ b/src/main/java/alexthw/not_enough_glyphs/init/ArsNouveauRegistry.java
@@ -36,6 +36,7 @@ import com.hollingsworth.arsnouveau.api.spell.ITurretBehavior;
 import com.hollingsworth.arsnouveau.api.spell.SpellResolver;
 import com.hollingsworth.arsnouveau.api.spell.SpellStats;
 import com.hollingsworth.arsnouveau.common.block.tile.RotatingTurretTile;
+import com.hollingsworth.arsnouveau.common.items.PerkItem;
 import com.hollingsworth.arsnouveau.common.spell.augment.AugmentDampen;
 import com.hollingsworth.arsnouveau.common.spell.effect.EffectReset;
 import com.hollingsworth.arsnouveau.setup.registry.APIRegistry;
@@ -45,9 +46,11 @@ import net.minecraft.core.Position;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.fml.ModList;
 import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.RegisterEvent;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -149,10 +152,6 @@ public class ArsNouveauRegistry {
                     MethodArcProjectile.INSTANCE, MethodHomingProjectile.INSTANCE,
                     PropagatorArc.INSTANCE, PropagatorHoming.INSTANCE)
             );
-            registerPerk(FocusPerk.ELEMENTAL_FIRE);
-            registerPerk(FocusPerk.ELEMENTAL_WATER);
-            registerPerk(FocusPerk.ELEMENTAL_EARTH);
-            registerPerk(FocusPerk.ELEMENTAL_AIR);
         }
 
         //ex scalaes
@@ -162,25 +161,54 @@ public class ArsNouveauRegistry {
         if (!ModList.get().isLoaded("ars_controle"))
             register(FilterRandom.INSTANCE);
 
-        //perks
-        registerPerk(FocusPerk.MANIPULATION);
-        registerPerk(FocusPerk.SUMMONING);
-        registerPerk(RandomPerk.INSTANCE);
-        registerPerk(PacificThread.INSTANCE);
-        registerPerk(BulldozeThread.INSTANCE);
-        registerPerk(SharpThread.INSTANCE);
-        registerPerk(PounchThread.INSTANCE);
-
-        registerPerk(SpellCritChancePerk.INSTANCE);
-        registerPerk(SpellCritDamagePerk.INSTANCE);
-
     }
 
-    public static void registerPerk(IPerk perk) {
-        // Maps both the old and the new to act as alias when loading a world post-switch
+    /**
+     * Registers our perks and their backing perk-items.
+     * <p>
+     * This runs from {@link net.neoforged.neoforge.registries.RegisterEvent} for the item registry, NOT from the mod
+     * constructor. Ars Nouveau materialises a {@code PerkItem} for every entry in {@link PerkRegistry#getPerkMap()} at the
+     * time its own item {@code RegisterEvent} handler fires. The old code populated that shared map from our (parallel) mod
+     * constructor, and put each perk under two keys (the {@code ars_nouveau:} alias and our own id) — so Ars Nouveau's
+     * sweep saw each perk twice and registered its item twice. How many of those duplicate registrations actually landed
+     * depended on construct/class-load ordering and resolved differently per side: the dedicated server registered each
+     * {@code not_enough_glyphs:thread_*} item twice (13 extra raw ids) while the client registered each once. On join the
+     * client remaps to the server's id set, leaving those 13 server-only ids as null ITEM holders (and crashing any mod
+     * that iterates the ITEM registry on join).
+     * <p>
+     * Because Not Enough Glyphs depends on Ars Nouveau, our {@code RegisterEvent} listeners fire after Ars Nouveau's, so
+     * its perk-map sweep never sees these perks. We therefore register each perk-item ourselves here exactly once,
+     * deterministically and single-threaded, identically on both sides.
+     */
+    public static void registerPerks(RegisterEvent.RegisterHelper<Item> helper) {
+        if (arsElemental) {
+            registerPerk(helper, FocusPerk.ELEMENTAL_FIRE);
+            registerPerk(helper, FocusPerk.ELEMENTAL_WATER);
+            registerPerk(helper, FocusPerk.ELEMENTAL_EARTH);
+            registerPerk(helper, FocusPerk.ELEMENTAL_AIR);
+        }
+
+        registerPerk(helper, FocusPerk.MANIPULATION);
+        registerPerk(helper, FocusPerk.SUMMONING);
+        registerPerk(helper, RandomPerk.INSTANCE);
+        registerPerk(helper, PacificThread.INSTANCE);
+        registerPerk(helper, BulldozeThread.INSTANCE);
+        registerPerk(helper, SharpThread.INSTANCE);
+        registerPerk(helper, PounchThread.INSTANCE);
+
+        registerPerk(helper, SpellCritChancePerk.INSTANCE);
+        registerPerk(helper, SpellCritDamagePerk.INSTANCE);
+    }
+
+    public static void registerPerk(RegisterEvent.RegisterHelper<Item> helper, IPerk perk) {
+        PerkRegistry.registerPerk(perk);
+        // Mirror Ars Nouveau's ItemsRegistry#onItemRegistry: create and register the backing perk-item ourselves.
+        PerkItem perkItem = new PerkItem(perk);
+        PerkRegistry.getPerkItemMap().put(perk.getRegistryName(), perkItem);
+        helper.register(perk.getRegistryName(), perkItem);
+        // Maps the old ars_nouveau-namespaced id to ours so worlds saved before the namespace switch keep loading.
         var oldVersion = ArsNouveau.prefix(perk.getRegistryName().getPath());
         PerkRegistry.getPerkMap().put(oldVersion, perk);
-        PerkRegistry.registerPerk(perk);
         BuiltInRegistries.ITEM.addAlias(oldVersion, perk.getRegistryName());
     }
 

--- a/src/main/java/alexthw/not_enough_glyphs/init/NotEnoughGlyphs.java
+++ b/src/main/java/alexthw/not_enough_glyphs/init/NotEnoughGlyphs.java
@@ -2,6 +2,7 @@ package alexthw.not_enough_glyphs.init;
 
 import alexthw.not_enough_glyphs.ClientStuff;
 import com.alexthw.sauce.Sauce;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
@@ -9,6 +10,7 @@ import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.fml.loading.FMLEnvironment;
+import net.neoforged.neoforge.registries.RegisterEvent;
 
 // The value here should match an entry in the META-INF/neoforge.mods.toml file
 @Mod(NotEnoughGlyphs.MODID)
@@ -22,6 +24,7 @@ public class NotEnoughGlyphs {
         Registry.init(modEventBus);
         ArsNouveauRegistry.registerGlyphs();
         modEventBus.addListener(Networking::register);
+        modEventBus.addListener(this::registerItems);
         modEventBus.addListener(this::setup);
         modEventBus.addListener(this::doClientStuff);
 
@@ -34,6 +37,12 @@ public class NotEnoughGlyphs {
 
     public static ResourceLocation prefix(String path) {
         return ResourceLocation.fromNamespaceAndPath(MODID, path);
+    }
+
+    private void registerItems(final RegisterEvent event) {
+        // Perk-items are registered here (deterministic, single-threaded) instead of via Ars Nouveau's perk-map sweep,
+        // which was being populated from the parallel mod constructor. See ArsNouveauRegistry#registerPerks.
+        event.register(Registries.ITEM, ArsNouveauRegistry::registerPerks);
     }
 
     private void setup(final FMLCommonSetupEvent event) {


### PR DESCRIPTION
## Summary

NEG registers its 13 `not_enough_glyphs:thread_*` perk-items a non-deterministic number of times: on a dedicated server each one lands in the `ITEM` registry **twice**, while on the physical client each lands **once**. On multiplayer join the client remaps its `ITEM` registry to the server's id set, so the 13 server-only duplicate ids have no client-side item, leaving 13 `null` `Holder.Reference` entries. Any mod that then iterates the full `ITEM` registry on join NPEs (in our pack the trigger was Supplementaries' `InteractEventsHandler.registerOverrides`, but NEG is the underlying cause).

## Environment

- Not Enough Glyphs 1.21.1 (observed on 4.6.0; code path unchanged on current `1.21` HEAD / 4.6.1)
- Ars Nouveau 5.12.0, Ars Elemental 0.7.10.0
- NeoForge 21.1.230, Minecraft 1.21.1

## Evidence (observed, reproducible)

Per-namespace `ITEM`-registry histograms, captured at `TagsUpdatedEvent` on both sides, are identical for every mod **except** NEG:

- Client: `not_enough_glyphs` = 29
- Dedicated server: `not_enough_glyphs` = 42 (delta = 13)

The 13 ids that are `null` on the client map server-side to exactly these items:
`thread_{fire,water,air,earth,summon,shaper}_focus`, `thread_slow_power`, `thread_scritchance`, `thread_wild_magic`, `thread_cheap_damage`, `thread_sharp_paper`, `thread_knockback`, `thread_scritdamage`, i.e. exactly the perks registered through `ArsNouveauRegistry.registerPerk(...)`.

Crash signature (observed verbatim on the test client):
```
java.lang.NullPointerException: Packet handling error
  at ...supplementaries...InteractEventsHandler.registerOverrides(InteractEventsHandler.java:97)
  at ...ClientConfigurationPacketListenerImpl.handleConfigurationFinished(:127)
  Type: clientbound/minecraft:finish_configuration
```
(Supplementaries here is 3.6.7; it is only the registry iterator that trips over NEG's null holders, not the cause.)

## Root cause

The 13 perk-items are never registered by NEG directly. The chain is:

1. NEG's `@Mod` constructor calls `ArsNouveauRegistry.registerGlyphs()` synchronously (parallel CONSTRUCT phase). For each perk, `registerPerk(...)` puts it into Ars Nouveau's shared `PerkRegistry` perk-map under **two** keys: `PerkRegistry.getPerkMap().put(ars_nouveau:thread_x, perk)` (the back-compat alias) **and** `PerkRegistry.registerPerk(perk)`, which does `perkMap.put(not_enough_glyphs:thread_x, perk)`.
2. Later, Ars Nouveau's `ItemsRegistry.onItemRegistry(RegisterEvent.RegisterHelper<Item>)` does `for (IPerk perk : PerkRegistry.getPerkMap().values()) helper.register(perk.getRegistryName(), new PerkItem(perk))`. Each NEG perk appears in `values()` **twice**, so Ars Nouveau registers `not_enough_glyphs:thread_x` twice, producing two `byId` slots per perk.

How many times each perk-item lands in the `ITEM` registry therefore depends on what is in the shared map when Ars Nouveau's sweep fires, and the map is mutated from the parallel construct phase. This resolves differently between the two JVMs: **the dedicated server double-registers all 13 (26 raw ids), while the physical client registers each once (13 raw ids).** On join the client remaps to the server's id set, and the 13 server-only duplicate ids have no client-side `PerkItem`, leaving 13 null `Holder.Reference` entries, which is the `registerOverrides` NPE.

This was verified directly (see Verification): the broken server's `ITEM` registry contains **26** `not_enough_glyphs:thread_*` entries (each of the 13 perks at two raw ids), so its "42" is really `29 real + 13 duplicates`. The correct, deterministic count is **29**.

## Fix

Stop relying on Ars Nouveau's incidental sweep of the shared perk-map. Register NEG's perk-items ourselves, from NEG's own `RegisterEvent` for the `ITEM` registry: single-threaded, in the proper registration phase, identical on both physical sides. This mirrors `ItemsRegistry.onItemRegistry`: for each perk we `PerkRegistry.registerPerk(perk)`, build a `PerkItem`, populate `getPerkItemMap()`, `helper.register(...)`, and keep the `ars_nouveau:` to `not_enough_glyphs:` `addAlias` for backwards compatibility with worlds saved before the namespace switch.

Because NEG depends on Ars Nouveau, NEG's `RegisterEvent` listeners fire **after** Ars Nouveau's, so its perk-map sweep never double-registers these; NEG owns them outright.

`registerGlyphs()` keeps doing the spell-part registration in the constructor unchanged; only the perk path moved.

## Verification

Builds (`./gradlew build`) against Ars Nouveau 5.12.0 / Ars Elemental 0.7.10.0 / NeoForge 21.1.230.

Tested end-to-end on a dedicated server plus physical client running a ~150-mod 1.21.1 pack (the full Ars stack: Nouveau, Elemental, Additions, Elemancy, Ocultas, Technica, plus Supplementaries), using a small diagnostic mod that walks `BuiltInRegistries.ITEM` by raw id at `TagsUpdatedEvent` on both sides:

| | broken 4.6.0 | this fix |
|---|---|---|
| Server `not_enough_glyphs` items | 42 (= **26** `thread_*` raw ids: each of 13 perks registered twice) | **29** (13 `thread_*`, each once) |
| Client `not_enough_glyphs` items | 29, **13 null/unbound holders** | **29**, no null holders |
| `ITEM` `byId` size | client 20897 / server 20897 | **20884 on both** |
| Multiplayer join | NPE in `registerOverrides` at `finish_configuration` | **clean join** |

Both sides now register each perk exactly once and agree on the full `ITEM` id set, so the join-time remap leaves no null holders.
